### PR TITLE
Ignore fossa-analyze failures

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,17 @@ steps:
     api_key:
       from_secret: FOSSA_API_KEY
     debug: true
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/*"
+        - "refs/tags/*"
+        - "refs/pull/*"
+    event:
+      - push
+      - tag
 
 - name: fossa-test
   image: rancher/drone-fossa:latest
@@ -18,6 +29,17 @@ steps:
       from_secret: FOSSA_API_KEY
     command: test
     debug: true
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/*"
+        - "refs/tags/*"
+        - "refs/pull/*"
+    event:
+      - push
+      - tag
 
 ---
 kind: pipeline
@@ -33,4 +55,15 @@ steps:
       from_secret: docker_password
     repo: rancher/drone-fossa
     tags: latest
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/*"
+        - "refs/tags/*"
+        - "refs/pull/*"
+    event:
+      - push
+      - tag
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,6 +5,7 @@ name: fossa
 steps:
 - name: fossa-analyze
   image: rancher/drone-fossa:latest
+  failure: ignore
   settings:
     api_key:
       from_secret: FOSSA_API_KEY


### PR DESCRIPTION
The fossa-analyze job fails to detect a project which means the fossa-test job never runs.