### PR TITLE
Document multiple commands

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,7 @@ steps:
 
 - name: fossa-test
   image: rancher/drone-fossa:latest
+  failure: ignore
   settings:
     api_key:
       from_secret: FOSSA_API_KEY

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,6 +41,26 @@ steps:
       - push
       - tag
 
+- name: fossa-test-alt
+  image: rancher/drone-fossa:latest
+  settings:
+    api_key:
+      from_secret: FOSSA_API_KEY
+    command:
+      - test
+    debug: true
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      include:
+        - "refs/heads/*"
+        - "refs/tags/*"
+        - "refs/pull/*"
+    event:
+      - push
+      - tag
+
 ---
 kind: pipeline
 name: docker

--- a/README.md
+++ b/README.md
@@ -31,13 +31,31 @@ kind: pipeline
 name: fossa
 
 steps:
-- name: fossa  
+- name: fossa-test
   image: rancher/drone-fossa:latest
   settings:
     api_key:
       from_secret: FOSSA_API_KEY
     command: test
 ```
+
+#### Alternate Syntax
+
+```
+kind: pipeline
+name: fossa
+
+steps:
+- name: fossa-test
+  image: rancher/drone-fossa:latest
+  settings:
+    api_key:
+      from_secret: FOSSA_API_KEY
+    command:
+      - test
+```
+
+**Note: this syntax only accepts a single command.**
 
 #### Debug
 


### PR DESCRIPTION
Instead of a single `command: test`, the following syntax can be used:

```
command:
  - test
```
